### PR TITLE
修改固定连接以兼容图片地址

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: HAS-LAB
 description: The computer world is a world of dialect.
-permalink: /:year/:month/:day/:title:output_ext
+permalink: /:year/:title:output_ext
 exclude: [project, src, build.sbt, CNAME, LICENSE, README.md]
 
 collections:


### PR DESCRIPTION
博客页面采用``/:year/:title:output_ext``可使得图片显示兼容更多地方。使用类似``../images/date-filename``的文件地址，可以在博客页、Github页和VSC等更多地方正确显示图片。