### PR TITLE
添加自动安装脚本

### DIFF
--- a/_docs/website/index.md
+++ b/_docs/website/index.md
@@ -13,3 +13,10 @@ order: 1
 ```shell
 bundle exec jekyll serve --host localhost --port 4040
 ```
+
+Ubuntu/Debian下直接尝试下面命令一键安装+测试：
+
+```
+bin/serve
+```
+

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+apt_install="ruby-dev zlib1g-dev"
+
+for pkt in "make gcc g++"
+do
+    if [ "$(which ${pkt})" = "" ]; then
+        apt_install="$apt_install $pkt"
+    fi
+done
+
+echo "sudo apt install $apt_install"
+sudo apt update
+sudo apt install $apt_install
+
+gem install --user-install bundler
+
+RUBY_VERSION=$(ruby -e 'print "#{ RUBY_VERSION }"')
+
+if [ -d "$HOME/.gem/ruby/${RUBY_VERSION}/bin" ] ; then
+    echo PATH=\"\$HOME/.gem/ruby/${RUBY_VERSION}/bin:\$PATH\" >> $HOME/.profile
+fi
+
+. $HOME/.profile
+
+bundle config set --local path ~/.gem
+
+bundle install

--- a/bin/serve
+++ b/bin/serve
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+if [ "$(which bundle)" = "" ]; then
+    bin/install
+
+    RUBY_VERSION=$(ruby -e 'print "#{ RUBY_VERSION }"')
+
+    if [ -d "$HOME/.gem/ruby/${RUBY_VERSION}/bin" ] ; then
+        PATH="$HOME/.gem/ruby/${RUBY_VERSION}/bin:$PATH"
+    fi
+fi
+
 bundle exec jekyll serve --host localhost --port 9000


### PR DESCRIPTION
Ubuntu下直接运行``bin/serve``可在本地启动测试。

需要在新机器中测试脚本正确性。